### PR TITLE
Preserve bundle constraints

### DIFF
--- a/core/bundle_pack.go
+++ b/core/bundle_pack.go
@@ -51,15 +51,9 @@ func NewBundlePack(bid bundle.BundleID, store *storage.Store) BundlePack {
 }
 
 func NewBundlePackFromBundle(b bundle.Bundle, store *storage.Store) BundlePack {
-	bp := BundlePack{
-		Id:          b.ID(),
-		Receiver:    bundle.DtnNone(),
-		Timestamp:   time.Now(),
-		Constraints: make(map[Constraint]bool),
+	bp := NewBundlePack(b.ID(), store)
 
-		bndl:  &b,
-		store: store,
-	}
+	bp.bndl = &b
 
 	bp.Sync()
 	return bp

--- a/core/processing.go
+++ b/core/processing.go
@@ -289,6 +289,8 @@ func (c *Core) forward(bp BundlePack) {
 		} else if c.InspectAllBundles && bp.MustBundle().IsAdministrativeRecord() {
 			c.bundleContraindicated(bp)
 			c.checkAdministrativeRecord(bp)
+		} else {
+			c.bundleContraindicated(bp)
 		}
 	} else {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
When creating a bundle pack, read existing constraints from the store