### PR TITLE
Fix issue preventing EndpointID registration

### DIFF
--- a/cla/manager.go
+++ b/cla/manager.go
@@ -314,8 +314,9 @@ func (manager *Manager) Receiver() (crs []ConvergenceReceiver) {
 }
 
 func (manager *Manager) RegisterEndpointID(claType CLAType, eid bundle.EndpointID) {
-	var clas []bundle.EndpointID
-	if clas, ok := manager.listenerIDs[claType]; ok {
+	clas, ok := manager.listenerIDs[claType]
+
+	if ok {
 		clas = append(clas, eid)
 	} else {
 		clas = []bundle.EndpointID{eid}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -5,9 +5,10 @@ package discovery
 import (
 	"bytes"
 	"fmt"
-	"github.com/dtn7/dtn7-go/cla"
 	"io"
 	"strings"
+
+	"github.com/dtn7/dtn7-go/cla"
 
 	"github.com/dtn7/cboring"
 	"github.com/dtn7/dtn7-go/bundle"

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,9 +1,10 @@
 package discovery
 
 import (
-	"github.com/dtn7/dtn7-go/cla"
 	"reflect"
 	"testing"
+
+	"github.com/dtn7/dtn7-go/cla"
 
 	"github.com/dtn7/dtn7-go/bundle"
 )


### PR DESCRIPTION
As it turns out, I still don't fully understand go's rules for scoping
and so the previous version of the code always assigned an empty slice
for each clatype.