### PR TITLE
Fix deadlock in CLA manager

### DIFF
--- a/pkg/cla/manager.go
+++ b/pkg/cla/manager.go
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
-// SPDX-FileCopyrightText: 2020 Markus Sommer
+// SPDX-FileCopyrightText: 2020, 2021 Markus Sommer
+// SPDX-FileCopyrightText: 2021 Artur Sterz
+// SPDX-FileCopyrightText: 2021 Jonas Höchst
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +15,8 @@ import (
 
 	"github.com/dtn7/dtn7-go/pkg/bpv7"
 )
+
+const ReportChannelBuffer = 100
 
 // Manager monitors and manages the various CLAs, restarts them if necessary,
 // and forwards the ConvergenceStatus messages. The recipient can perform
@@ -62,8 +66,8 @@ func NewManager() *Manager {
 
 		listenerIDs: make(map[CLAType][]bpv7.EndpointID),
 
-		inChnl:  make(chan ConvergenceStatus, 100),
-		outChnl: make(chan ConvergenceStatus),
+		inChnl:  make(chan ConvergenceStatus, ReportChannelBuffer),
+		outChnl: make(chan ConvergenceStatus, ReportChannelBuffer),
 
 		stopSyn: make(chan struct{}),
 		stopAck: make(chan struct{}),
@@ -117,10 +121,21 @@ func (manager *Manager) handler() {
 				}).Info("CLA Manager received Peer Disappeared, restarting CLA")
 
 				manager.Restart(cs.Sender)
-				manager.outChnl <- cs
+
+				select {
+				case manager.outChnl <- cs:
+					continue
+				default:
+					log.Error("outChnl full or no consumer.")
+				}
 
 			default:
-				manager.outChnl <- cs
+				select {
+				case manager.outChnl <- cs:
+					continue
+				default:
+					log.Error("outChnl full or no consumer.")
+				}
 			}
 
 		case <-activateTicker.C:

--- a/pkg/cla/manager_elem.go
+++ b/pkg/cla/manager_elem.go
@@ -1,4 +1,7 @@
 // SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
+// SPDX-FileCopyrightText: 2021 Markus Sommer
+// SPDX-FileCopyrightText: 2021 Artur Sterz
+// SPDX-FileCopyrightText: 2021 Jonas Höchst
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -85,7 +88,12 @@ func (ce *convergenceElem) handler() {
 				"status": cs.String(),
 			}).Debug("Forwarding ConvergenceStatus to Manager")
 
-			ce.convChnl <- cs
+			select {
+			case ce.convChnl <- cs:
+				continue
+			default:
+				log.WithField("cla", ce.conv).Error("convChnl full or no consumer.")
+			}
 		}
 	}
 }


### PR DESCRIPTION
While using `dtn7-go` in a large-ish setup, we found that the daemon would regularly lock up completely. We eventually traced the problem to the interaction between the cla-manager, manager-elem and cla itself (in our case mtcp, but the issue would potentially exist for any cla with synchronisation problems).

In the end it comes down to the fact that both unbuffered channel writes and the respective `Close()`-methods of the manager-elem and cla are blocking. The created a situation where the manager would call the manager-elem's `Close()`-method and block, while the manager-elem could not react to it, since it was blocked by a channel send to the manager which would also never resolve - thus a global deadlock.

Out first-order solution to this issue was to make the channel-writes for the reporting channels non-blocking, using a select-guard. In order to prevent message loss if there is not currently someone listening on the channel, we turned the channels from unbuffered to buffered channels (sizer of the buffer configurable using the `ReportChannelBuffer` const in `manager.go`.

C&C welcome.