### PR TITLE
Distinguish different CLA instances during restart

### DIFF
--- a/pkg/cla/manager.go
+++ b/pkg/cla/manager.go
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
-// SPDX-FileCopyrightText: 2020 Markus Sommer
+// SPDX-FileCopyrightText: 2020, 2021 Markus Sommer
+// SPDX-FileCopyrightText: 2021 Artur Sterz
+// SPDX-FileCopyrightText: 2021 Jonas Höchst
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -266,7 +268,18 @@ func (manager *Manager) unregisterConvergence(conv Convergence) {
 		return
 	}
 
-	convElem.(*convergenceElem).deactivate(manager.queueTtl)
+	element := convElem.(*convergenceElem)
+
+	if element.conv != conv {
+		log.WithFields(log.Fields{
+			"cla":     conv,
+			"address": conv.Address(),
+		}).Error("CLA not unregistered, different instance.")
+
+		return
+	}
+
+	element.deactivate(manager.queueTtl)
 	manager.convs.Delete(conv.Address())
 }
 


### PR DESCRIPTION
There may be a situation where there are multiple PeerDisappeared-messages for the same CLA waiting to be processed.
This might cause the manager to restart the same CLA multiple times in quick succession.
To prevent this, we can check if the pointer to the CLA from the PeerDisappeared-message points to the same instance as the one currently stored in the manager's `convs` map.