### PR TITLE
Dont try to lock mutex when closing mtcp-client

### DIFF
--- a/pkg/cla/mtcp/client.go
+++ b/pkg/cla/mtcp/client.go
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2019, 2021 Markus Sommer
 // SPDX-FileCopyrightText: 2019, 2020, 2021 Alvar Penning
+// SPDX-FileCopyrightText: 2021 Artur Sterz
+// SPDX-FileCopyrightText: 2021 Jonas Höchst
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -84,12 +86,10 @@ func (client *MTCPClient) handler() {
 	for {
 		select {
 		case <-client.stopSyn:
-			client.mutex.Lock()
 			_ = client.conn.Close()
 
 			close(client.reportChan)
 			close(client.stopAck)
-			client.mutex.Unlock()
 
 			return
 


### PR DESCRIPTION
There appears to be no real reason to wait for senders to finish when we want to terminate the CLA (particularly since we are probably doing this because the connection has collapsed, so there won't be any further sending happening on that socket)