### PR TITLE
Make convergenceElem.ttl atomic

### DIFF
--- a/pkg/cla/manager.go
+++ b/pkg/cla/manager.go
@@ -20,7 +20,7 @@ import (
 // CLA administration themselves.
 type Manager struct {
 	// queueTtl is the amount of retries for a CLA.
-	queueTtl int
+	queueTtl int32
 
 	// retryTime is the duration between two activation attempts.
 	retryTime time.Duration


### PR DESCRIPTION
This way we can avoid locking the mutex as part of `convergenceElem.isActive()`, which may prevent a deadlock