### PR TITLE
Workflow for extended tests

### DIFF
--- a/.github/workflows/extended_tests.yml
+++ b/.github/workflows/extended_tests.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Run extended tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Send repository_dispatch event to dtn7-playground repo
+      run: |
+        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/dtn7/dtn7-playground/dispatches --data '{"event_type": "run"}'


### PR DESCRIPTION
As can be seen in recent issues and PRs (#39, #40, #41, #42, #43, #45), there
is an issue in dtn7-go that results in a deadlock after some time, making it
impossible to sent bundles. To be able to test and debug this issue, some more
extensive tests are required. Thus, we developed a test infrastructure to
simulate multiple virtual nodes using the [CORE emulator](https://github.com/coreemu/core).
This tests environment is located in the [dtn7-playground](https://github.com/dtn7/dtn7-playground) repository.
To be able to trigger these tests, this PR adds a workflow file, that uses the
[repository_dispatch event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch) sent to the dtn7-playground repo.