### PR TITLE
Modify Bundle.AddExtensionBlock

### DIFF
--- a/pkg/bpv7/bundle.go
+++ b/pkg/bpv7/bundle.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2018, 2019, 2020 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -96,9 +97,16 @@ func (b *Bundle) sortBlocks() {
 	sort.Sort(canonicalBlockNumberSort(b.CanonicalBlocks))
 }
 
-// AddExtensionBlock adds a new ExtensionBlock to this Bundle. The block number
-// will be calculated and overwritten within this method.
-func (b *Bundle) AddExtensionBlock(block CanonicalBlock) {
+// AddExtensionBlock adds a new ExtensionBlock to this Bundle.
+//
+// The block number will be calculated and overwritten within this method.
+// Will return an error if the Bundle already has an ExtensionBlock with the same type code.
+func (b *Bundle) AddExtensionBlock(block CanonicalBlock) error {
+	blockType := block.Value.BlockTypeCode()
+	if b.HasExtensionBlock(blockType) {
+		return fmt.Errorf("bundle %v already has ExtensionBlock with type code %v", b.ID(), blockType)
+	}
+
 	var blockNumbers []uint64
 	for i := 0; i < len(b.CanonicalBlocks); i++ {
 		blockNumbers = append(blockNumbers, b.CanonicalBlocks[i].BlockNumber)
@@ -129,6 +137,7 @@ func (b *Bundle) AddExtensionBlock(block CanonicalBlock) {
 
 	b.CanonicalBlocks = append(b.CanonicalBlocks, block)
 	b.sortBlocks()
+	return nil
 }
 
 // RemoveExtensionBlockByBlockNumber searches and removes a CanonicalBlock / ExtensionBlock with the given block number.

--- a/pkg/bpv7/bundle_test.go
+++ b/pkg/bpv7/bundle_test.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2018, 2019, 2020, 2021 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -230,7 +231,10 @@ func TestBundleAddRemoveExtensionBlocks(t *testing.T) {
 	if b.HasExtensionBlock(ExtBlockTypePreviousNodeBlock) {
 		t.Fatalf("previous node block is present")
 	}
-	b.AddExtensionBlock(NewCanonicalBlock(0, 0, NewPreviousNodeBlock(MustNewEndpointID("dtn://prev/"))))
+	err = b.AddExtensionBlock(NewCanonicalBlock(0, 0, NewPreviousNodeBlock(MustNewEndpointID("dtn://prev/"))))
+	if err != nil {
+		t.Fatalf("adding PreviousNodeBlock resulted in error: %v", err)
+	}
 	if !b.HasExtensionBlock(ExtBlockTypePreviousNodeBlock) {
 		t.Fatalf("previous node block is not present")
 	}

--- a/pkg/bpv7/extension_block_signature_test.go
+++ b/pkg/bpv7/extension_block_signature_test.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -160,7 +161,11 @@ func TestSignatureBlockIntegration(t *testing.T) {
 		t.Fatal(sbErr)
 	}
 
-	b1.AddExtensionBlock(NewCanonicalBlock(0, ReplicateBlock|DeleteBundle, sb))
+	err := b1.AddExtensionBlock(NewCanonicalBlock(0, ReplicateBlock|DeleteBundle, sb))
+	if err != nil {
+		t.Fatalf("Adding ExtensionBlock caused error: %v", err)
+	}
+
 	b1.SetCRCType(CRC32)
 
 	var buff bytes.Buffer
@@ -245,7 +250,10 @@ func TestSignatureBlockFragmentSimple(t *testing.T) {
 
 	cb := NewCanonicalBlock(0, ReplicateBlock|DeleteBundle, sb)
 	cb.SetCRCType(CRC32)
-	b1.AddExtensionBlock(cb)
+	err := b1.AddExtensionBlock(cb)
+	if err != nil {
+		t.Fatalf("Error adding ExtensionBlock: %v", err)
+	}
 
 	bs, bsErr := b1.Fragment(256)
 	if bsErr != nil {


### PR DESCRIPTION
Have Bundle.AddExtensionBlock return an error if you try to add an
ExtensionBlock which already exists, since the recipient of a Bundle
will drop it if it contains multiple blocks with the same type code.