### PR TITLE
Harmonise `Bundle` and `BundleDescriptor` API

### DIFF
--- a/pkg/cla/convergence_layer.go
+++ b/pkg/cla/convergence_layer.go
@@ -58,6 +58,8 @@ type Convergence interface {
 
 	// IsPermanent returns true, if this CLA should not be removed after failures.
 	IsPermanent() bool
+
+	// TODO: String method for address-logging
 }
 
 // ConvergenceReceiver is an interface for types which are able to receive

--- a/pkg/routing/algorithm_dtlsr.go
+++ b/pkg/routing/algorithm_dtlsr.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
-// SPDX-FileCopyrightText: 2019, 2021 Markus Sommer
+// SPDX-FileCopyrightText: 2019, 2021, 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -270,7 +270,7 @@ func (dtlsr *DTLSR) SenderForBundle(bp BundleDescriptor) (sender []cla.Convergen
 	if !present {
 		// we don't know where to forward this bundle
 		log.WithFields(log.Fields{
-			"bundle":    bp.ID(),
+			"bundle":    bp.ID().String(),
 			"recipient": recipient,
 		}).Debug("DTLSR could not find a node to forward to")
 		return
@@ -294,7 +294,7 @@ func (dtlsr *DTLSR) SenderForBundle(bp BundleDescriptor) (sender []cla.Convergen
 	}
 
 	log.WithFields(log.Fields{
-		"bundle":    bp.ID(),
+		"bundle":    bp.ID().String(),
 		"recipient": recipient,
 	}).Debug("DTLSR could not find forwarder amongst connected nodes")
 	return

--- a/pkg/routing/algorithm_epidemic.go
+++ b/pkg/routing/algorithm_epidemic.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 Markus Sommer
+// SPDX-FileCopyrightText: 2019, 2022 Markus Sommer
 // SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -70,7 +70,7 @@ func (er *EpidemicRouting) NotifyNewBundle(bp BundleDescriptor) {
 	}
 
 	log.WithFields(log.Fields{
-		"bundle": bp.ID(),
+		"bundle": bp.ID().String(),
 		"eid":    prevNode,
 	}).Debug("EpidemicRouting received an incoming bundle and checked its PreviousNodeBlock")
 
@@ -86,7 +86,7 @@ func (er *EpidemicRouting) clasForBundle(bp BundleDescriptor, updateDb bool) (cs
 	bi, biErr := er.c.store.QueryId(bp.Id)
 	if biErr != nil {
 		log.WithFields(log.Fields{
-			"bundle": bp.ID(),
+			"bundle": bp.ID().String(),
 			"error":  biErr,
 		}).Warn("Failed to proceed a non-stored Bundle")
 		return nil, false
@@ -95,7 +95,7 @@ func (er *EpidemicRouting) clasForBundle(bp BundleDescriptor, updateDb bool) (cs
 	css, sentEids := filterCLAs(bi, er.c.claManager.Sender(), "epidemic")
 
 	log.WithFields(log.Fields{
-		"bundle": bp.ID(),
+		"bundle": bp.ID().String(),
 		"sent":   sentEids,
 	}).Debug("EpidemicRouting is processing an outgoing bundle")
 
@@ -109,7 +109,7 @@ func (er *EpidemicRouting) clasForBundle(bp BundleDescriptor, updateDb bool) (cs
 	}
 
 	log.WithFields(log.Fields{
-		"bundle":              bp.ID(),
+		"bundle":              bp.ID().String(),
 		"sent":                sentEids,
 		"convergence-senders": css,
 	}).Debug("EpidemicRouting selected Convergence Senders for an outbounding bundle")
@@ -124,7 +124,7 @@ func (er *EpidemicRouting) DispatchingAllowed(bp BundleDescriptor) bool {
 	bi, biErr := er.c.store.QueryId(bp.Id)
 	if biErr != nil {
 		log.WithFields(log.Fields{
-			"bundle": bp.ID(),
+			"bundle": bp.ID().String(),
 			"error":  biErr,
 		}).Warn("Failed to proceed a non-stored Bundle")
 
@@ -169,7 +169,7 @@ func (er *EpidemicRouting) ReportFailure(bp BundleDescriptor, sender cla.Converg
 	}
 
 	log.WithFields(log.Fields{
-		"bundle":  bp.ID(),
+		"bundle":  bp.ID().String(),
 		"bad_cla": sender,
 		"sent":    sentEids,
 	}).Debug("EpidemicRouting failed to transmit to CLA")

--- a/pkg/routing/algorithm_prophet.go
+++ b/pkg/routing/algorithm_prophet.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019, 2021 Markus Sommer
+// SPDX-FileCopyrightText: 2019, 2021, 2022 Markus Sommer
 // SPDX-FileCopyrightText: 2020 Alvar Penning
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -250,7 +250,7 @@ func (prophet *Prophet) NotifyNewBundle(bp BundleDescriptor) {
 	}
 
 	log.WithFields(log.Fields{
-		"bundle": bp.ID(),
+		"bundle": bp.ID().String(),
 		"eid":    prevNode,
 	}).Debug("Prophet received an incomming bundle and checked its PreviousNodeBlock")
 
@@ -378,7 +378,7 @@ func (prophet *Prophet) ReportFailure(bp BundleDescriptor, sender cla.Convergenc
 	bundleItem, err := prophet.c.store.QueryId(bp.Id)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"bundle": bp.ID(),
+			"bundle": bp.ID().String(),
 			"error":  err.Error(),
 		}).Warn("Failed to get bundle metadata")
 		return
@@ -388,13 +388,13 @@ func (prophet *Prophet) ReportFailure(bp BundleDescriptor, sender cla.Convergenc
 	if !ok {
 		// this shouldn't really happen, no?
 		log.WithFields(log.Fields{
-			"bundle": bp.ID(),
+			"bundle": bp.ID().String(),
 		}).Warn("Bundle had no stored sender-list")
 		return
 	}
 
 	log.WithFields(log.Fields{
-		"bundle": bp.ID(),
+		"bundle": bp.ID().String(),
 		"peer":   sender,
 	}).Info("Failed to transmit bundle")
 
@@ -409,14 +409,14 @@ func (prophet *Prophet) ReportFailure(bp BundleDescriptor, sender cla.Convergenc
 
 	if err := prophet.c.store.Update(bundleItem); err != nil {
 		log.WithFields(log.Fields{
-			"bundle": bp.ID(),
+			"bundle": bp.ID().String(),
 			"error":  err,
 		}).Warn("Updating BundleItem failed")
 		return
 	}
 
 	log.WithFields(log.Fields{
-		"bundle": bp.ID(),
+		"bundle": bp.ID().String(),
 		"peer":   sender,
 		"clas":   sentEids,
 	}).Debug("Removed peer from sent list")

--- a/pkg/routing/algorithm_sensornetwork.go
+++ b/pkg/routing/algorithm_sensornetwork.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -63,7 +64,7 @@ func (snm *SensorNetworkMuleRouting) SenderForBundle(bp BundleDescriptor) (sende
 	// Filter sender list: Remove sensor nodes iff a bundle is not addressed to it.
 	for i := len(sender) - 1; i >= 0; i-- {
 		logger := log.WithFields(log.Fields{
-			"bundle":             bp.ID(),
+			"bundle":             bp.ID().String(),
 			"convergence-sender": sender[i],
 		})
 

--- a/pkg/routing/bundle_descriptor.go
+++ b/pkg/routing/bundle_descriptor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 Markus Sommer
+// SPDX-FileCopyrightText: 2019, 2022 Markus Sommer
 // SPDX-FileCopyrightText: 2020, 2021 Alvar Penning
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -122,8 +122,8 @@ func (descriptor *BundleDescriptor) MustBundle() *bpv7.Bundle {
 }
 
 // ID returns the wrapped Bundle's ID.
-func (descriptor BundleDescriptor) ID() string {
-	return descriptor.Id.String()
+func (descriptor BundleDescriptor) ID() bpv7.BundleID {
+	return descriptor.Id
 }
 
 // HasReceiver returns true if this BundleDescriptor has a Receiver value.
@@ -197,7 +197,7 @@ func (descriptor *BundleDescriptor) UpdateBundleAge() (uint64, error) {
 func (descriptor BundleDescriptor) String() string {
 	var b strings.Builder
 
-	_, _ = fmt.Fprintf(&b, "BundleDescriptor(%v,", descriptor.ID())
+	_, _ = fmt.Fprintf(&b, "BundleDescriptor(%v,", descriptor.ID().String())
 	for c := range descriptor.Constraints {
 		_, _ = fmt.Fprintf(&b, " %v", c)
 	}

--- a/pkg/routing/core.go
+++ b/pkg/routing/core.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2019, 2020 Alvar Penning
-// SPDX-FileCopyrightText: 2019, 2020 Markus Sommer
+// SPDX-FileCopyrightText: 2019, 2020, 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -244,7 +244,7 @@ func (c *Core) SendStatusReport(descriptor BundleDescriptor, status bpv7.StatusI
 	}
 
 	log.WithFields(log.Fields{
-		"bundle": descriptor.ID(),
+		"bundle": descriptor.ID().String(),
 		"status": status,
 		"reason": reason,
 	}).Info("Sending a status report for a bundle")
@@ -253,7 +253,7 @@ func (c *Core) SendStatusReport(descriptor BundleDescriptor, status bpv7.StatusI
 	var ar, arErr = bpv7.AdministrativeRecordToCbor(sr)
 	if arErr != nil {
 		log.WithFields(log.Fields{
-			"bundle": descriptor.ID(),
+			"bundle": descriptor.ID().String(),
 			"error":  arErr,
 		}).Warn("Serializing administrative record failed")
 
@@ -267,7 +267,7 @@ func (c *Core) SendStatusReport(descriptor BundleDescriptor, status bpv7.StatusI
 
 	if !c.HasEndpoint(aaEndpoint) && aaEndpoint != c.NodeId {
 		log.WithFields(log.Fields{
-			"bundle":   descriptor.ID(),
+			"bundle":   descriptor.ID().String(),
 			"endpoint": aaEndpoint,
 		}).Warn("Failed to create status report, receiver is not a current endpoint")
 
@@ -285,7 +285,7 @@ func (c *Core) SendStatusReport(descriptor BundleDescriptor, status bpv7.StatusI
 
 	if err != nil {
 		log.WithFields(log.Fields{
-			"bundle": descriptor.ID(),
+			"bundle": descriptor.ID().String(),
 			"error":  err,
 		}).Warn("Creating status report bundle failed")
 

--- a/pkg/routing/pipeline.go
+++ b/pkg/routing/pipeline.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -98,7 +99,7 @@ func (pipeline *Pipeline) sendReport(descriptor BundleDescriptor, status bpv7.St
 	}
 
 	pipeline.log().WithFields(log.Fields{
-		"origin": descriptor.ID(), "status": status, "reason": reason,
+		"origin": descriptor.ID().String(), "status": status, "reason": reason,
 	}).Info("creating status report for bundle")
 
 	reportBundle, err := bpv7.Builder().
@@ -110,7 +111,7 @@ func (pipeline *Pipeline) sendReport(descriptor BundleDescriptor, status bpv7.St
 		StatusReport(descriptor.MustBundle(), status, reason).
 		Build()
 	if err != nil {
-		pipeline.log().WithField("origin", descriptor.ID()).WithError(err).Warn("status report creation errored")
+		pipeline.log().WithField("origin", descriptor.ID().String()).WithError(err).Warn("status report creation errored")
 	} else {
 		pipeline.queue <- pipelineMsg{t: sendBundle, v: reportBundle}
 	}

--- a/pkg/routing/pipeline_local.go
+++ b/pkg/routing/pipeline_local.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,16 +21,16 @@ func (pipeline *Pipeline) localDelivery(descriptor BundleDescriptor) pipelineFun
 		return pipeline.localNodeRecord
 	} else if pipeline.AgentManager.HasEndpoint(descriptor.MustBundle().PrimaryBlock.Destination) {
 		if err := pipeline.AgentManager.Deliver(descriptor); err == nil {
-			pipeline.log().WithField("bundle", descriptor.ID()).Info("delivered bundle to a local agent")
+			pipeline.log().WithField("bundle", descriptor.ID().String()).Info("delivered bundle to a local agent")
 			descriptor.AddTag(Delivered)
 		} else {
-			pipeline.log().WithError(err).WithField("bundle", descriptor.ID()).Warn("local delivery failed")
+			pipeline.log().WithError(err).WithField("bundle", descriptor.ID().String()).Warn("local delivery failed")
 			descriptor.AddTag(NoLocalAgent)
 		}
 
 		return nil
 	} else {
-		pipeline.log().WithField("bundle", descriptor.ID()).Info("no local agent for incoming bundle")
+		pipeline.log().WithField("bundle", descriptor.ID().String()).Info("no local agent for incoming bundle")
 		descriptor.AddTag(NoLocalAgent)
 		return nil
 	}
@@ -37,7 +38,7 @@ func (pipeline *Pipeline) localDelivery(descriptor BundleDescriptor) pipelineFun
 
 // localFragment handles fragmented bundles addressed to this node.
 func (pipeline *Pipeline) localFragment(descriptor BundleDescriptor) pipelineFunc {
-	pipeline.log().WithField("bundle", descriptor.ID()).Info("received fragmented bundle")
+	pipeline.log().WithField("bundle", descriptor.ID().String()).Info("received fragmented bundle")
 	descriptor.AddTag(ReassemblyPending)
 
 	// TODO
@@ -47,12 +48,12 @@ func (pipeline *Pipeline) localFragment(descriptor BundleDescriptor) pipelineFun
 // localNodeRecord handles administrative records addressed to this node's node id.
 func (pipeline *Pipeline) localNodeRecord(descriptor BundleDescriptor) pipelineFunc {
 	if adminRecord, err := descriptor.MustBundle().AdministrativeRecord(); err != nil {
-		pipeline.log().WithError(err).WithField("bundle", descriptor.ID()).Warn("no administrative record is present")
+		pipeline.log().WithError(err).WithField("bundle", descriptor.ID().String()).Warn("no administrative record is present")
 		return nil
 	} else if adminRecord.RecordTypeCode() == bpv7.AdminRecordTypeStatusReport {
 		return pipeline.localNodeStatusReport
 	} else {
-		pipeline.log().WithField("bundle", descriptor.ID()).Warn("unsupported administrative record")
+		pipeline.log().WithField("bundle", descriptor.ID().String()).Warn("unsupported administrative record")
 		return nil
 	}
 }

--- a/pkg/routing/pipeline_pre.go
+++ b/pkg/routing/pipeline_pre.go
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020, 2021 Alvar Penning
+// SPDX-FileCopyrightText: 2022 Markus Sommer
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -31,14 +32,14 @@ func (pipeline *Pipeline) receiveCheckBlocks(descriptor BundleDescriptor) pipeli
 
 		if canonical.BlockControlFlags.Has(bpv7.DeleteBundle) {
 			pipeline.log().WithFields(log.Fields{
-				"bundle": descriptor.ID(), "block": canonical.BlockNumber,
+				"bundle": descriptor.ID().String(), "block": canonical.BlockNumber,
 			}).Info("deleting bundle because of an unknown block")
 
 			descriptor.AddTag(Faulty)
 			break
 		} else if canonical.BlockControlFlags.Has(bpv7.RemoveBlock) {
 			pipeline.log().WithFields(log.Fields{
-				"bundle": descriptor.ID(), "block": canonical.BlockNumber,
+				"bundle": descriptor.ID().String(), "block": canonical.BlockNumber,
 			}).Info("removing unknown block")
 
 			descriptor.MustBundle().RemoveExtensionBlockByBlockNumber(canonical.BlockNumber)
@@ -69,7 +70,7 @@ func (pipeline *Pipeline) processInitial(descriptor BundleDescriptor) pipelineFu
 
 	for _, checkFunc := range pipeline.Checks {
 		if err := checkFunc(pipeline, descriptor); err != nil {
-			pipeline.log().WithField("bundle", descriptor.ID()).WithError(err).Warn("preprocessing check failed")
+			pipeline.log().WithField("bundle", descriptor.ID().String()).WithError(err).Warn("preprocessing check failed")
 
 			descriptor.AddTag(Faulty)
 			break


### PR DESCRIPTION
Both structs have an ID() method, however in the case of `Bundle`, this returned a `BundleID`-struct, while in case of `BundleDescriptor`, it returned a string-representation of the Id.

This caused confusion on multiple occasions, since in many cases theses two types are used in close proximity to one another and if you used the `Bundle`'s `ID`-method you might end up having the raw `EndpointID` struct dumped in you logs.

Now in both cases, the `ID`-method returns an `EndpointID` struct, and in any case where we want to log a bundle's id, we call the `String`-method explicitly.